### PR TITLE
Fix bullet rotation: separate movement direction from visual rotation

### DIFF
--- a/js/GameScene.js
+++ b/js/GameScene.js
@@ -2379,8 +2379,9 @@ export class GameScene extends BaseScene {
                     enemyContext.x + enemyContext.unit.hitArea.x + enemyContext.unit.hitArea.width / 2 - bullet.unit.width / 2,
                     enemyContext.y + enemyContext.unit.hitArea.y + enemyContext.unit.hitArea.height / 2 // Center Y? Or bottom?
                 );
-                // Determine bullet direction (e.g., towards player or straight down)
-                bullet.rotation = 90 * Math.PI / 180; // Straight down
+                // Set movement direction and visual rotation
+                bullet.rotation = 90 * Math.PI / 180; // Straight down (movement direction)
+                bullet.character.rotation = -Math.PI / 2; // Rotate sprite 90 degrees CCW to point down
                 bullet.speed = bulletData.speed || 3; // Use default speed if not specified
 
                 bullet.on(Bullet.CUSTOM_EVENT_DEAD_COMPLETE, () => this.removeEnemyBulletById(bullet.id));

--- a/js/Player.js
+++ b/js/Player.js
@@ -917,9 +917,11 @@ export class Player extends BaseUnit {
          switch (this.shootMode) {
              case SHOOT_MODES.NORMAL: {
                  const bullet = new Bullet(this.shootNormalData);
-                 bullet.unit.rotation = 270 * Math.PI / 180;
-                 bullet.unit.x = this.unit.x + 5 * Math.sin(bullet.unit.rotation) + 14;
-                 bullet.unit.y = this.unit.y + 5 * Math.sin(bullet.unit.rotation) + 11;
+                 const rotation = 270 * Math.PI / 180; // -90 degrees for upward movement
+                 bullet.rotation = rotation; // Movement direction
+                 bullet.unit.rotation = rotation; // Visual rotation
+                 bullet.unit.x = this.unit.x + 5 * Math.sin(rotation) + 14;
+                 bullet.unit.y = this.unit.y + 5 * Math.sin(rotation) + 11;
                  bullet.name = SHOOT_MODES.NORMAL;
                  bullet.id = this.bulletIdCnt++;
                  bullet.shadowReverse = false;
@@ -934,9 +936,11 @@ export class Player extends BaseUnit {
              }
              case SHOOT_MODES.BIG: {
                  const bullet = new Bullet(this.shootBigData);
-                 bullet.unit.rotation = 270 * Math.PI / 180;
-                 bullet.unit.x = this.unit.x + 5 * Math.sin(bullet.unit.rotation) + 10;
-                 bullet.unit.y = this.unit.y + 5 * Math.sin(bullet.unit.rotation) + 22;
+                 const rotation = 270 * Math.PI / 180; // -90 degrees for upward movement
+                 bullet.rotation = rotation; // Movement direction
+                 bullet.unit.rotation = rotation; // Visual rotation
+                 bullet.unit.x = this.unit.x + 5 * Math.sin(rotation) + 10;
+                 bullet.unit.y = this.unit.y + 5 * Math.sin(rotation) + 22;
                  bullet.name = SHOOT_MODES.BIG;
                  bullet.id = this.bulletIdCnt++;
                  bullet.shadowReverse = false;
@@ -952,18 +956,25 @@ export class Player extends BaseUnit {
              case SHOOT_MODES.THREE_WAY: {
                  for (let i = 0; i < 3; i++) {
                      const bullet = new Bullet(this.shoot3wayData);
+                     let rotation;
                      if (i === 0) {
-                         bullet.unit.rotation = 280 * Math.PI / 180;
-                         bullet.unit.x = this.unit.x + 5 * Math.cos(bullet.unit.rotation) + 14;
-                         bullet.unit.y = this.unit.y + 5 * Math.sin(bullet.unit.rotation) + 11;
+                         rotation = 280 * Math.PI / 180;
+                         bullet.rotation = rotation; // Movement direction
+                         bullet.unit.rotation = rotation; // Visual rotation
+                         bullet.unit.x = this.unit.x + 5 * Math.cos(rotation) + 14;
+                         bullet.unit.y = this.unit.y + 5 * Math.sin(rotation) + 11;
                      } else if (i === 1) {
-                         bullet.unit.rotation = 270 * Math.PI / 180;
-                         bullet.unit.x = this.unit.x + 5 * Math.cos(bullet.unit.rotation) + 10;
-                         bullet.unit.y = this.unit.y + 5 * Math.sin(bullet.unit.rotation) + 11;
+                         rotation = 270 * Math.PI / 180;
+                         bullet.rotation = rotation; // Movement direction
+                         bullet.unit.rotation = rotation; // Visual rotation
+                         bullet.unit.x = this.unit.x + 5 * Math.cos(rotation) + 10;
+                         bullet.unit.y = this.unit.y + 5 * Math.sin(rotation) + 11;
                      } else if (i === 2) {
-                         bullet.unit.rotation = 260 * Math.PI / 180;
-                         bullet.unit.x = this.unit.x + 5 * Math.cos(bullet.unit.rotation) + 6;
-                         bullet.unit.y = this.unit.y + 5 * Math.sin(bullet.unit.rotation) + 11;
+                         rotation = 260 * Math.PI / 180;
+                         bullet.rotation = rotation; // Movement direction
+                         bullet.unit.rotation = rotation; // Visual rotation
+                         bullet.unit.x = this.unit.x + 5 * Math.cos(rotation) + 6;
+                         bullet.unit.y = this.unit.y + 5 * Math.sin(rotation) + 11;
                      }
                      bullet.id = this.bulletIdCnt++;
                      bullet.shadowReverse = false;


### PR DESCRIPTION
Fixed two issues with bullet orientation and movement:

Problem 1: Player bullets
- Visual: Facing correct direction (up)
- Movement: Moving right instead of up
- Root cause: Only set bullet.unit.rotation (visual), not bullet.rotation (movement)

Solution:
- Set both bullet.rotation (movement direction) and bullet.unit.rotation (visual)
- Movement uses bullet.rotation in Bullet.loop() via Math.cos/sin
- Visual rotation is separate for display purposes

Problem 2: Enemy bullets
- Visual: Facing left instead of down
- Movement: Moving correctly (down)
- Root cause: Only set bullet.rotation (movement), not bullet.character.rotation (visual)

Solution:
- Added bullet.character.rotation = -Math.PI/2 for visual downward orientation
- This rotates sprite 90 degrees CCW to point down
- Matches app_formatted.js pattern for standard enemy bullets

Changes:
- Player.js: Set both bullet.rotation and bullet.unit.rotation for all shoot modes
- GameScene.js: Added bullet.character.rotation for default enemy bullets

🤖 Generated with [Claude Code](https://claude.com/claude-code)