### PR TITLE
Match app_formatted.js bullet implementation exactly

### DIFF
--- a/js/Bullet.js
+++ b/js/Bullet.js
@@ -100,10 +100,10 @@ export class _Bullet extends BaseUnit {
                  this.y += (Math.cos(this.cont / 5) + 2.5 * this.speed) * delta;
             }
         } else {
-             // Standard bullet movement (e.g., upwards for player, downwards for enemy)
-             // Assuming rotation is set correctly externally
-             this.x += Math.cos(this.rotation) * this.speed * delta;
-             this.y += Math.sin(this.rotation) * this.speed * delta;
+             // Standard bullet movement using unit.rotation (matches app_formatted.js)
+             // Movement based on unit.rotation like original: e.unit.x += 3.5 * Math.cos(e.unit.rotation)
+             this.unit.x += this.speed * Math.cos(this.unit.rotation) * delta;
+             this.unit.y += this.speed * Math.sin(this.unit.rotation) * delta;
         }
 
          // Off-screen check should be handled by the scene managing the bullets
@@ -321,10 +321,10 @@ export class Bullet extends BaseUnit {
                  this.y += (Math.cos(this.cont / 5) + 2.5 * this.speed) * delta;
             }
         } else {
-             // Standard bullet movement (e.g., upwards for player, downwards for enemy)
-             // Assuming rotation is set correctly externally
-             this.x += Math.cos(this.rotation) * this.speed * delta;
-             this.y += Math.sin(this.rotation) * this.speed * delta;
+             // Standard bullet movement using unit.rotation (matches app_formatted.js)
+             // Movement based on unit.rotation like original: e.unit.x += 3.5 * Math.cos(e.unit.rotation)
+             this.unit.x += this.speed * Math.cos(this.unit.rotation) * delta;
+             this.unit.y += this.speed * Math.sin(this.unit.rotation) * delta;
         }
 
          // Off-screen check should be handled by the scene managing the bullets

--- a/js/Player.js
+++ b/js/Player.js
@@ -917,11 +917,9 @@ export class Player extends BaseUnit {
          switch (this.shootMode) {
              case SHOOT_MODES.NORMAL: {
                  const bullet = new Bullet(this.shootNormalData);
-                 const rotation = 270 * Math.PI / 180; // -90 degrees for upward movement
-                 bullet.rotation = rotation; // Movement direction
-                 bullet.unit.rotation = rotation; // Visual rotation (rotate container to face up)
-                 bullet.unit.x = this.unit.x + 5 * Math.sin(rotation) + 14;
-                 bullet.unit.y = this.unit.y + 5 * Math.sin(rotation) + 11;
+                 bullet.unit.rotation = 270 * Math.PI / 180; // Rotation for movement and visual (matches app_formatted.js)
+                 bullet.unit.x = this.unit.x + 5 * Math.sin(bullet.unit.rotation) + 14;
+                 bullet.unit.y = this.unit.y + 5 * Math.sin(bullet.unit.rotation) + 11;
                  bullet.name = SHOOT_MODES.NORMAL;
                  bullet.id = this.bulletIdCnt++;
                  bullet.shadowReverse = false;
@@ -936,11 +934,9 @@ export class Player extends BaseUnit {
              }
              case SHOOT_MODES.BIG: {
                  const bullet = new Bullet(this.shootBigData);
-                 const rotation = 270 * Math.PI / 180; // -90 degrees for upward movement
-                 bullet.rotation = rotation; // Movement direction
-                 bullet.unit.rotation = rotation; // Visual rotation (rotate container to face up)
-                 bullet.unit.x = this.unit.x + 5 * Math.sin(rotation) + 10;
-                 bullet.unit.y = this.unit.y + 5 * Math.sin(rotation) + 22;
+                 bullet.unit.rotation = 270 * Math.PI / 180; // Rotation for movement and visual (matches app_formatted.js)
+                 bullet.unit.x = this.unit.x + 5 * Math.sin(bullet.unit.rotation) + 10;
+                 bullet.unit.y = this.unit.y + 5 * Math.sin(bullet.unit.rotation) + 22;
                  bullet.name = SHOOT_MODES.BIG;
                  bullet.id = this.bulletIdCnt++;
                  bullet.shadowReverse = false;
@@ -956,25 +952,18 @@ export class Player extends BaseUnit {
              case SHOOT_MODES.THREE_WAY: {
                  for (let i = 0; i < 3; i++) {
                      const bullet = new Bullet(this.shoot3wayData);
-                     let rotation;
                      if (i === 0) {
-                         rotation = 280 * Math.PI / 180;
-                         bullet.rotation = rotation; // Movement direction
-                         bullet.unit.rotation = rotation; // Visual rotation
-                         bullet.unit.x = this.unit.x + 5 * Math.cos(rotation) + 14;
-                         bullet.unit.y = this.unit.y + 5 * Math.sin(rotation) + 11;
+                         bullet.unit.rotation = 280 * Math.PI / 180;
+                         bullet.unit.x = this.unit.x + 5 * Math.cos(bullet.unit.rotation) + 14;
+                         bullet.unit.y = this.unit.y + 5 * Math.sin(bullet.unit.rotation) + 11;
                      } else if (i === 1) {
-                         rotation = 270 * Math.PI / 180;
-                         bullet.rotation = rotation; // Movement direction
-                         bullet.unit.rotation = rotation; // Visual rotation
-                         bullet.unit.x = this.unit.x + 5 * Math.cos(rotation) + 10;
-                         bullet.unit.y = this.unit.y + 5 * Math.sin(rotation) + 11;
+                         bullet.unit.rotation = 270 * Math.PI / 180;
+                         bullet.unit.x = this.unit.x + 5 * Math.cos(bullet.unit.rotation) + 10;
+                         bullet.unit.y = this.unit.y + 5 * Math.sin(bullet.unit.rotation) + 11;
                      } else if (i === 2) {
-                         rotation = 260 * Math.PI / 180;
-                         bullet.rotation = rotation; // Movement direction
-                         bullet.unit.rotation = rotation; // Visual rotation
-                         bullet.unit.x = this.unit.x + 5 * Math.cos(rotation) + 6;
-                         bullet.unit.y = this.unit.y + 5 * Math.sin(rotation) + 11;
+                         bullet.unit.rotation = 260 * Math.PI / 180;
+                         bullet.unit.x = this.unit.x + 5 * Math.cos(bullet.unit.rotation) + 6;
+                         bullet.unit.y = this.unit.y + 5 * Math.sin(bullet.unit.rotation) + 11;
                      }
                      bullet.id = this.bulletIdCnt++;
                      bullet.shadowReverse = false;


### PR DESCRIPTION
Fixed player bullet rotation by using unit.rotation for both movement and visual orientation, matching the original implementation.

Key Changes:

1. Bullet.loop() - Changed standard movement to use unit.rotation: Before: this.x += Math.cos(this.rotation) * this.speed After:  this.unit.x += this.speed * Math.cos(this.unit.rotation)

   This matches app_formatted.js line 890: e.unit.x += 3.5 * Math.cos(e.unit.rotation)

2. Player.shoot() - Use only unit.rotation (not separate rotation): Before: bullet.rotation = 270°; bullet.unit.rotation = 270° After:  bullet.unit.rotation = 270° (only)

   This matches app_formatted.js lines 901-902: (o = new S(this.shootNormalData)).unit.rotation = 270 * Math.PI / 180

Why this works:
- In app_formatted.js, bullets use unit.rotation for BOTH movement and visual
- Setting unit.rotation rotates the entire container (sprite + shadow)
- The bullet moves using unit.rotation via Math.cos/sin in loop
- At 270° (3π/2 radians), cos=0 and sin=-1, giving upward movement
- Visual sprite also faces upward when container is rotated 270°

🤖 Generated with [Claude Code](https://claude.com/claude-code)