### PR TITLE
fix: prevent duplicate event listeners causing player/bullet multipli…

### DIFF
--- a/js/GameScene.js
+++ b/js/GameScene.js
@@ -1736,16 +1736,29 @@ export class GameScene extends BaseScene {
 
         // --- Setup Input Handling for Player ---
         // Add a transparent interactive graphic covering the game area
-        this.inputLayer = new PIXI.Graphics();
-        this.inputLayer.beginFill(0xFFFFFF, 0); // Transparent
-        this.inputLayer.drawRect(0, 0, Constants.GAME_DIMENSIONS.WIDTH, Constants.GAME_DIMENSIONS.HEIGHT);
-        this.inputLayer.endFill();
-        this.inputLayer.interactive = true;
+        if (!this.inputLayer) {
+            this.inputLayer = new PIXI.Graphics();
+            this.inputLayer.beginFill(0xFFFFFF, 0); // Transparent
+            this.inputLayer.drawRect(0, 0, Constants.GAME_DIMENSIONS.WIDTH, Constants.GAME_DIMENSIONS.HEIGHT);
+            this.inputLayer.endFill();
+            this.inputLayer.interactive = true;
+            this.addChild(this.inputLayer); // Add on top, but behind HUD/Overlays potentially
+            console.log("Input Layer created");
+        } else {
+            // Clear existing listeners before re-attaching
+            this.inputLayer.removeAllListeners('pointerdown');
+            this.inputLayer.removeAllListeners('pointermove');
+            this.inputLayer.removeAllListeners('pointerup');
+            this.inputLayer.removeAllListeners('pointerupoutside');
+            this.inputLayer.interactive = true;
+            console.log("Input Layer reused, listeners cleared");
+        }
+
+        // Attach listeners to the inputLayer
         this.inputLayer.on('pointerdown', this.player.onScreenDragStart, this.player);
         this.inputLayer.on('pointermove', this.player.onScreenDragMove, this.player);
         this.inputLayer.on('pointerup', this.player.onScreenDragEnd, this.player);
         this.inputLayer.on('pointerupoutside', this.player.onScreenDragEnd, this.player);
-        this.addChild(this.inputLayer); // Add on top, but behind HUD/Overlays potentially
         this.setChildIndex(this.inputLayer, this.children.length - 3); // Place behind HUD and Overlay containers
 
         this.player.attachInputListeners(); // Attach keyboard listeners

--- a/js/Player.js
+++ b/js/Player.js
@@ -786,6 +786,7 @@ export class Player extends BaseUnit {
         // --- Event Listeners ---
         this.keyDownListener = this.onKeyDown.bind(this);
         this.keyUpListener = this.onKeyUp.bind(this);
+        this._listenersAttached = false; // Flag to track listener state
 
          // Adjust hitArea based on actual sprite size
          this.unit.hitArea = new PIXI.Rectangle(
@@ -808,17 +809,19 @@ export class Player extends BaseUnit {
     // --- Input Handling ---
     // These should be attached/detached by the scene managing the player
     attachInputListeners() {
-        if (typeof document !== 'undefined') {
-            document.addEventListener("keydown", this.keyDownListener);
-            document.addEventListener("keyup", this.keyUpListener);
-        }
+        if (this._listenersAttached || typeof document === 'undefined') return; // Don't attach multiple times
+        console.log("Attaching Player keyboard listeners.");
+        document.addEventListener("keydown", this.keyDownListener);
+        document.addEventListener("keyup", this.keyUpListener);
+        this._listenersAttached = true;
     }
 
     detachInputListeners() {
-        if (typeof document !== 'undefined') {
-            document.removeEventListener("keydown", this.keyDownListener);
-            document.removeEventListener("keyup", this.keyUpListener);
-        }
+        if (!this._listenersAttached || typeof document === 'undefined') return; // Don't detach if not attached
+        console.log("Detaching Player keyboard listeners.");
+        document.removeEventListener("keydown", this.keyDownListener);
+        document.removeEventListener("keyup", this.keyUpListener);
+        this._listenersAttached = false;
     }
 
      // Pointer events should be handled by the scene's input layer


### PR DESCRIPTION
…cation

Fixed critical bug where event listeners were being attached multiple times, causing player movement and bullets to multiply and fly off screen too fast.

Changes:
- Added `_listenersAttached` flag to Player class to prevent multiple keyboard listener attachments
- Modified attachInputListeners() to check flag before attaching listeners
- Modified detachInputListeners() to properly reset flag
- Updated GameScene.js to reuse inputLayer and clear listeners before re-attaching to prevent duplicate pointer event listeners

Resolves issue where using arrow keys or dragging player caused bullets and sprites to multiply and accelerate uncontrollably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)