### PR TITLE
fix: correct lerp factor to prevent player flying off screen

### DIFF
--- a/js/Player.js
+++ b/js/Player.js
@@ -885,7 +885,8 @@ export class Player extends BaseUnit {
         }
 
          // Smooth movement towards target using lerp (linear interpolation)
-         const lerpFactor = 0.09 * delta * 60; // Adjust lerp factor based on delta
+         // Delta is typically 1.0 at 60fps, so we just use 0.09 as the lerp factor
+         const lerpFactor = 0.09; // Keep constant for smooth movement
          this.x += lerpFactor * (this.unitX - this.x);
          // Player Y is usually fixed or handled differently, lerping might not be desired
          // this.y += lerpFactor * (this.unitY - this.y);


### PR DESCRIPTION
Fixed critical bug where lerp factor was calculated as 5.4 instead of 0.09, causing player to massively overshoot target position and fly off screen.

The issue was in Player.js:888 where:
- Before: `const lerpFactor = 0.09 * delta * 60;` (= 5.4 at 60fps)
- After: `const lerpFactor = 0.09;` (proper lerp value between 0-1)

A lerp factor > 1 causes overshooting where the player moves multiple times the distance to the target each frame, resulting in exponential acceleration off screen. This also caused bullets (which are children of the player) to fly off with the player.

The PIXI ticker delta is typically 1.0 at 60fps (representing frames, not seconds), so multiplying by 60 was incorrect and caused the massive overshoot.