### PR TITLE
fix: hide unit container on death to prevent collision with destroyed…

### DIFF
--- a/js/Bullet.js
+++ b/js/Bullet.js
@@ -389,6 +389,7 @@ export class Bullet extends BaseUnit {
         this.deadFlg = true;
         this.emit(BaseUnit.CUSTOM_EVENT_DEAD); // Notify manager
 
+        this.unit.visible = false;      // Hide unit (prevents collision detection)
         this.character.visible = false; // Hide character
         this.shadow.visible = false;    // Hide shadow
 

--- a/js/Enemy.js
+++ b/js/Enemy.js
@@ -291,6 +291,7 @@ export class Enemy extends BaseUnit {
         Utils.dlog(`Enemy ${this.name} [ID:${this.id}] dead, emitting DEAD event.`);
         this.emit(BaseUnit.CUSTOM_EVENT_DEAD, this); // Notify manager, pass self
 
+        if (this.unit) this.unit.visible = false;        // Hide unit (prevents collision detection)
         if (this.character) this.character.visible = false; // Hide main sprite
         if (this.shadow) this.shadow.visible = false;    // Hide shadow
 

--- a/js/bosses/Boss.js
+++ b/js/bosses/Boss.js
@@ -197,6 +197,7 @@ export class Boss extends BaseUnit {
         this.shootOn = false; // Stop trying to start new attack patterns
         this.emit(BaseUnit.CUSTOM_EVENT_DEAD, this); // Notify manager
 
+        if (this.unit) this.unit.visible = false; // Hide unit immediately (prevents collision)
         this.character?.stop();
         this.shadow?.stop();
         this.tlShoot?.kill(); // Stop attack patterns
@@ -226,8 +227,8 @@ export class Boss extends BaseUnit {
         }
 
 
-        // Fade out the main unit container (character + shadow) after shaking/explosions start
-        TweenMax.to(this.unit, 1.0, { delay: 0.5, alpha: 0 });
+        // Unit is already hidden to prevent collision
+        // Explosions are added to main container instead of unit
 
         this.onDead(); // Hook for subclasses (e.g., play specific KO voice)
     }
@@ -251,7 +252,7 @@ export class Boss extends BaseUnit {
             explosionInstance.destroy(); // Clean up clone
          };
 
-         this.unit.addChild(explosionInstance); // Add explosions to the unit container
+         this.addChild(explosionInstance); // Add explosions to main container (not unit, since unit is hidden)
          explosionInstance.play();
          Sound.play('se_explosion');
      }
@@ -260,8 +261,7 @@ export class Boss extends BaseUnit {
         this.explotionCnt++;
         if (isVeryLast) {
             // Only emit DEAD_COMPLETE after the final explosion finishes
-             if(this.unit) this.unit.visible = false; // Ensure unit is hidden
-             this.visible = false;
+            this.visible = false;
             this.emit(BaseUnit.CUSTOM_EVENT_DEAD_COMPLETE, this);
         }
     }


### PR DESCRIPTION
… objects

This commit fixes the issue where player bullets would collide with destroyed enemies and bullets even though they were visually hidden.

Problem:
- When enemies/bullets died, only character.visible and shadow.visible were set to false
- The unit container (which holds the hitArea) remained visible
- This caused collision detection to continue working even though the visual was hidden

Solution:
- Set unit.visible = false immediately in dead() methods
- This prevents collision detection since hitTest checks obj.visible

Changes:
- Bullet.js: Set unit.visible = false in dead()
- Enemy.js: Set unit.visible = false in dead()
- Boss.js: Set unit.visible = false at start of dead()
- Boss.js: Move explosions from unit to main container so they remain visible