### PR TITLE
Fix boss timer speed issue

### DIFF
--- a/js/GameScene.js
+++ b/js/GameScene.js
@@ -358,7 +358,7 @@ export class GameScene extends BaseScene {
 
         // Boss Timer Logic
         if (this.bossTimerStartFlg && this.boss) {
-            this.bossTimerFrameCnt += delta * Constants.FPS;
+            this.bossTimerFrameCnt += delta;
             if (this.bossTimerFrameCnt >= Constants.FPS) { // Every second approx
                 this.bossTimerFrameCnt = 0;
                 this.bossTimerCountDown--;


### PR DESCRIPTION
Previously the timer was incrementing by delta * Constants.FPS, causing it to advance 30x faster than intended. Changed to increment by delta only, so it correctly counts 30 frames (1 second at 30 FPS) before decrementing the timer.