### PR TITLE
Fix shoot method after caFire call

### DIFF
--- a/js/GameScene.js
+++ b/js/GameScene.js
@@ -1188,6 +1188,8 @@ export class GameScene extends BaseScene {
                 }
                 this.theWorldFlg = false;
                 this.hud.caFireFlg = false;
+                // Restart player shooting after CA animation completes
+                if (this.player) this.player.shootStart();
                 if (this.boss) {
                     if (this.boss.hp <= 0) {
                         this.theWorldFlg = true;


### PR DESCRIPTION
The issue was that GameScene.caFire() called player.shootStop() to pause shooting during the CA animation, but never called player.shootStart() when the animation completed. This left the player unable to shoot after using the CA attack.

The fix adds player.shootStart() in the final timeline callback after theWorldFlg is set back to false, matching the behavior of the original app_formatted.js implementation where shooting automatically resumes when the game loop unfreezes.

Fixed in: js/GameScene.js:1192