### PR TITLE
Fix scene transition after boss defeat

### DIFF
--- a/js/GameScene.js
+++ b/js/GameScene.js
@@ -1286,7 +1286,7 @@ export class GameScene extends BaseScene {
 
     stageClear() {
         Utils.dlog("GameScene.stageClear()");
-        if (this.theWorldFlg && this.sceneSwitch !== 0) return; // Already transitioning
+        if (this.sceneSwitch !== 0) return; // Already transitioning
 
         this.theWorldFlg = true; // Prevent further updates
         this.sceneSwitch = 1; // Mark for transitioning to next stage/adv


### PR DESCRIPTION
Fix scene transition guard in stageClear() to prevent duplicate transitions. The previous guard used AND logic that could be bypassed if theWorldFlg was set to false during CA animation cleanup, allowing multiple scene transitions and incorrect stageId increments.

Now uses simpler sceneSwitch check to guarantee single transition.