### PR TITLE
fix: emit CUSTOM_EVENT_DEAD_COMPLETE after boss final explosion

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,6 @@
 TODO
 ====
 
-BossBison (Balrog) on death plays explosion anim and sound but nextScene not called
-
 Player - ondrag or keyup player disappears (double loop call from BaseScene?)
 
 soliderA bullets need to be rotated (-90)

--- a/js/bosses/Boss.js
+++ b/js/bosses/Boss.js
@@ -248,7 +248,7 @@ export class Boss extends BaseUnit {
          explosionInstance.y = (Math.random() - 0.5) * this.unit.hitArea.height;
 
          explosionInstance.onComplete = () => {
-            this.explosionComplete(explosionInstance, isLast && (this.explotionCnt === 5));
+            this.explosionComplete(explosionInstance, isLast);
             explosionInstance.destroy(); // Clean up clone
          };
 


### PR DESCRIPTION
Fixed bug where CUSTOM_EVENT_DEAD_COMPLETE was never emitted because the condition checked explotionCnt === 5 before it was incremented. This prevented the scene transition to AdvScene after boss defeat.

The fix passes isLast directly to explosionComplete since we already know which explosion is the last one from the spawn loop.

Closes issue: BossBison on death plays explosion anim and sound but nextScene not called.